### PR TITLE
fix(security): bypass allowed cmds

### DIFF
--- a/backend/terminal.ts
+++ b/backend/terminal.ts
@@ -219,7 +219,7 @@ export class MainTerminal extends InteractiveTerminal {
         // Check if the command is allowed
         const cmdParts = input.split(" ");
         const executable = cmdParts[0].trim();
-        const knownOperators = ["&&", "||", "&", ";"];
+        const knownOperators = ["||", "&", ";"];
         log.debug("console", "Executable: " + executable);
         log.debug("console", "Executable length: " + executable.length);
 

--- a/backend/terminal.ts
+++ b/backend/terminal.ts
@@ -219,11 +219,14 @@ export class MainTerminal extends InteractiveTerminal {
         // Check if the command is allowed
         const cmdParts = input.split(" ");
         const executable = cmdParts[0].trim();
+        const knownOperators = ["&&", "||", "&", ";"];
         log.debug("console", "Executable: " + executable);
         log.debug("console", "Executable length: " + executable.length);
 
         if (!allowedCommandList.includes(executable)) {
             throw new Error("Command not allowed.");
+        } else if (knownOperators.some(operator => input.includes(operator))) {
+            throw new Error("Control operators are not allowed.");
         }
         super.write(input);
     }


### PR DESCRIPTION
using control operators, you can use disallowed commands. see screenshot below for example.

this fix simply creates a list of all known operators that can be used and checks the input for them.

<img width="493" alt="image" src="https://github.com/asdfzxcvbn/dockge/assets/109937991/07dcb4a3-d9b7-4ef2-abd8-2b2c7120ab65">
