### PR TITLE
Support compose.y[a]ml and docker-compose.y[a]ml

### DIFF
--- a/backend/stack.ts
+++ b/backend/stack.ts
@@ -38,8 +38,8 @@ export class Stack {
 
         // Check if compose file name is different from compose.yaml
         const supportedFileNames = [ "compose.yaml", "compose.yml", "docker-compose.yml", "docker-compose.yaml" ];
-        for (const filename of supportedFileNames){
-            if (fs.existsSync(path.join(this.path, filename))){
+        for (const filename of supportedFileNames) {
+            if (fs.existsSync(path.join(this.path, filename))) {
                 this._composeFileName = filename;
                 break;
             }

--- a/backend/stack.ts
+++ b/backend/stack.ts
@@ -37,12 +37,12 @@ export class Stack {
         this._composeYAML = composeYAML;
 
         // Check if compose file name is different from compose.yaml
-        if (fs.existsSync(path.join(this.path, "compose.yml"))){
-            this._composeFileName = "compose.yml";
-        } else if (fs.existsSync(path.join(this.path, "docker-compose.yml"))){
-            this._composeFileName = "docker-compose.yml";
-        } else if (fs.existsSync(path.join(this.path, "docker-compose.yaml"))){
-            this._composeFileName = "docker-compose.yaml";
+        const supportedFileNames = [ "compose.yaml", "compose.yml", "docker-compose.yml", "docker-compose.yaml" ];
+        for (const filename of supportedFileNames){
+            if (fs.existsSync(path.join(this.path, filename))){
+                this._composeFileName = filename;
+                break;
+            }
         }
     }
 
@@ -160,7 +160,7 @@ export class Stack {
 
     async delete(socket?: DockgeSocket) : Promise<number> {
         const terminalName = getComposeTerminalName(this.name);
-        let exitCode = await Terminal.exec(this.server, socket, terminalName, "docker", [ "compose", "down", "--remove-orphans", "all" ], this.path);
+        let exitCode = await Terminal.exec(this.server, socket, terminalName, "docker", [ "compose", "down", "--remove-orphans" ], this.path);
         if (exitCode !== 0) {
             throw new Error("Failed to delete, please check the terminal output for more information.");
         }

--- a/backend/stack.ts
+++ b/backend/stack.ts
@@ -24,6 +24,7 @@ export class Stack {
     protected _status: number = UNKNOWN;
     protected _composeYAML?: string;
     protected _configFilePath?: string;
+    protected _composeFileName: string = "compose.yaml";
     protected server: DockgeServer;
 
     protected combinedTerminal? : Terminal;
@@ -34,6 +35,15 @@ export class Stack {
         this.name = name;
         this.server = server;
         this._composeYAML = composeYAML;
+
+        // Check if compose file name is different from compose.yaml
+        if (fs.existsSync(path.join(this.path, "compose.yml"))){
+            this._composeFileName = "compose.yml";
+        } else if (fs.existsSync(path.join(this.path, "docker-compose.yml"))){
+            this._composeFileName = "docker-compose.yml";
+        } else if (fs.existsSync(path.join(this.path, "docker-compose.yaml"))){
+            this._composeFileName = "docker-compose.yaml";
+        }
     }
 
     toJSON() : object {
@@ -50,6 +60,7 @@ export class Stack {
             status: this._status,
             tags: [],
             isManagedByDockge: this.isManagedByDockge,
+            composeFileName: this._composeFileName,
         };
     }
 
@@ -84,7 +95,7 @@ export class Stack {
     get composeYAML() : string {
         if (this._composeYAML === undefined) {
             try {
-                this._composeYAML = fs.readFileSync(path.join(this.path, "compose.yaml"), "utf-8");
+                this._composeYAML = fs.readFileSync(path.join(this.path, this._composeFileName), "utf-8");
             } catch (e) {
                 this._composeYAML = "";
             }
@@ -135,7 +146,7 @@ export class Stack {
         }
 
         // Write or overwrite the compose.yaml
-        fs.writeFileSync(path.join(dir, "compose.yaml"), this.composeYAML);
+        fs.writeFileSync(path.join(dir, this._composeFileName), this.composeYAML);
     }
 
     async deploy(socket? : DockgeSocket) : Promise<number> {

--- a/frontend/src/pages/Compose.vue
+++ b/frontend/src/pages/Compose.vue
@@ -118,7 +118,7 @@
                     </div>
                 </div>
                 <div class="col-lg-6">
-                    <h4 class="mb-3">compose.yaml</h4>
+                    <h4 class="mb-3">{{ stack.composeFileName }}</h4>
 
                     <!-- YAML editor -->
                     <div class="shadow-box mb-3 editor-box" :class="{'edit-mode' : isEditMode}">


### PR DESCRIPTION
This adds support for compose.yml, compose.yaml, docker-compose.yml and docker-compose.yaml. Default is still compose.yaml (f.e. new stacks created by dockge).

I hope i didn't miss anything, first time working with Vue and I haven't touched TS/JS in a while :) 

Resolves discussion https://github.com/louislam/dockge/discussions/10 