### PR TITLE
Add health status check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,5 +48,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Lint
+        run: pnpm run lint
       # more things can be add later like tests etc..
-      
+

--- a/backend/stack.ts
+++ b/backend/stack.ts
@@ -352,10 +352,10 @@ export class Stack {
             try {
                 let obj = JSON.parse(line);
                 if (obj.Health === "") {
-+                       statusList.set(obj.Service, obj.State);
-+               } else {
-+                       statusList.set(obj.Service, obj.Health);
-+               }
+                    statusList.set(obj.Service, obj.State);
+                } else {
+                    statusList.set(obj.Service, obj.Health);
+                }
             } catch (e) {
             }
         }

--- a/backend/stack.ts
+++ b/backend/stack.ts
@@ -351,7 +351,11 @@ export class Stack {
         for (let line of lines) {
             try {
                 let obj = JSON.parse(line);
-                statusList.set(obj.Service, obj.State);
+                if (obj.Health === "") {
++                       statusList.set(obj.Service, obj.State);
++               } else {
++                       statusList.set(obj.Service, obj.Health);
++               }
             } catch (e) {
             }
         }

--- a/frontend/src/components/Container.vue
+++ b/frontend/src/components/Container.vue
@@ -179,8 +179,10 @@ export default defineComponent({
         },
 
         bgStyle() {
-            if (this.status === "running") {
-                return "bg-primary";
+            if (this.status === "running" || this.status === "healthy") {
+                 return "bg-primary";
+            } else if (this.status === "unhealthy") {
+                 return "bg-danger";
             } else {
                 return "bg-secondary";
             }

--- a/frontend/src/components/Container.vue
+++ b/frontend/src/components/Container.vue
@@ -180,9 +180,9 @@ export default defineComponent({
 
         bgStyle() {
             if (this.status === "running" || this.status === "healthy") {
-                 return "bg-primary";
+                return "bg-primary";
             } else if (this.status === "unhealthy") {
-                 return "bg-danger";
+                return "bg-danger";
             } else {
                 return "bg-secondary";
             }


### PR DESCRIPTION
First of all, I dumped Portainer as soon as I found out about Dockge, but I am missing the health status.

This pull request results in the following picture, where:
- **basic-server** doesn't have a **healthcheck**
- **healthy-server** has a **healthcheck** with a test set to be healthy
- **unhealthy-server** has a **healthcheck** with a test set to be unhealthy

![Screenshot 3](https://github.com/louislam/dockge/assets/25776723/21dd8d17-6901-4e06-8855-45aa2413c2a2)

Compose used on example;
```yaml
version: "3.3"
services:
  basic-server:
    image: nginx:alpine
  healthy-server:
    image: nginx:alpine
    healthcheck:
      test:
        - CMD
        - ls
        - /etc
      interval: 1s
      timeout: 1s
      retries: 0
      start_period: 1s
  unhealthy-server:
    image: nginx:alpine
    healthcheck:
      test:
        - CMD
        - ls
        - /nope
      interval: 1s
      timeout: 1s
      retries: 0
      start_period: 1s
networks: {}
```

Just an initial idea, happy to discuss!