### PR TITLE
chore: Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
         uses: actions/checkout@v4
 
       - run: git config --global core.autocrlf false  # Mainly for Windows
-      - uses: actions/checkout@v3
 
       - name: Setup Node.js
         uses: actions/setup-node@v3


### PR DESCRIPTION
`actions/checkout@v4` is already there, no need for another `actions/checkout@v3`.