### PR TITLE
Specify filename to use for new stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ services:
     environment:
       # Tell Dockge where is your stacks directory
       - DOCKGE_STACKS_DIR=/opt/stacks
+      - COMPOSE_FILENAME=docker-compose.yml #Specify filename to use when creating new stack
 ```
 
 ## How to Update

--- a/backend/stack.ts
+++ b/backend/stack.ts
@@ -24,7 +24,7 @@ export class Stack {
     protected _status: number = UNKNOWN;
     protected _composeYAML?: string;
     protected _configFilePath?: string;
-    protected _composeFileName: string = "compose.yaml";
+    protected _composeFileName: string = process.env.COMPOSE_FILENAME || "compose.yaml";
     protected server: DockgeServer;
 
     protected combinedTerminal? : Terminal;


### PR DESCRIPTION
This PR adds feature #79 allowing users to specify what filename to use for new compose stacks