### PR TITLE
Add missing 'stackName' param to return value

### DIFF
--- a/backend/util-common.ts
+++ b/backend/util-common.ts
@@ -203,7 +203,7 @@ export function getContainerTerminalName(container : string) {
 }
 
 export function getContainerExecTerminalName(stackName : string, container : string, index : number) {
-    return "container-exec-" + container + "-" + index;
+    return "container-exec-" + stackName + "-" + container + "-" + index;
 }
 
 export function copyYAMLComments(doc : Document, src : Document) {


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/dockge/blob/master/CONTRIBUTING.md

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description
Maybe a mishap, but this was causing issues with opening the correct terminals for each container.

If containers from different stacks had the same service name (e.g. `stack1-server` and `stack2-server`), the frontend would bind a terminal based only on the service name and not open the correct one.

Steps to reproduce:
1. Deploy two or more stacks with the same service names, like:

`stack1`
```yaml
version: "3.8"
services:
  server:
    image: ...
...
```
`stack2`
```yaml
version: "3.8"
services:
  server:
    image: ...
...
```
2. Select one of the stacks (`stack1`)
3. Click to open the container's terminal from this stack (`stack1-server`)
4. Select the other stack (`stack2`)
5. Click to open the other terminal (should be `stack2-server`, but will be `stack1-server`)

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
