### PR TITLE
Interprets $TOKEN to it's .env file value for port parsing

### DIFF
--- a/frontend/src/components/Container.vue
+++ b/frontend/src/components/Container.vue
@@ -137,7 +137,7 @@
 <script>
 import { defineComponent } from "vue";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { parseDockerPort } from "../../../backend/util-common";
+import { interpretField, parseDockerPort } from "../../../backend/util-common";
 
 export default defineComponent({
     components: {
@@ -241,46 +241,13 @@ export default defineComponent({
     },
     methods: {
         parsePort(port) {
-            port = this.interpretField(port);
+            port = interpretField(port, this.$parent.$parent.stack.composeENV);
             let hostname = this.$root.info.primaryHostname || location.hostname;
             return parseDockerPort(port, hostname);
         },
         remove() {
             delete this.jsonObject.services[this.name];
         },
-        getEnvFileValue(key, defaultValue) {
-            let pattern = RegExp(`^${key}\\s*[=:]\\s*(?<value>.*(?=\\s#)|.*$)`, "mgi");
-            let match = pattern.exec(this.$parent.$parent.stack.composeENV);
-            let value = defaultValue;
-            if (match) {
-                value = match[1].trim(); // remove outer whitespace
-                // If wrapped in quotes, remove and unescape matching quotes
-                match = /^(['"])(.*(?<!\\))\1$/.exec(value);
-                if (match) {
-                    value = match[2].replace("\\" + match[1], match[1]);
-                }
-            }
-            return value;
-        },
-        interpretField(value) {
-            let pattern = /(?<!\$)\$(?:\{(?<fullname>.*?)\}|(?<name>\w+))/g;
-            let match;
-            while ((match = pattern.exec(value)) !== null) {
-                pattern.lastIndex = 0;
-                let name = match.groups.name;
-                let defaultValue = "";
-                if (!name) {
-                    name = match.groups.fullname.match(/^\w+/)[0];
-                    let defaultValueMatch = match.groups.fullname.match(/-(.*)$/);
-                    if (defaultValueMatch) {
-                        defaultValue = defaultValueMatch[1];
-                    }
-                }
-                let envValue = this.getEnvFileValue(name, defaultValue);
-                value = value.substring(0, match.index) + envValue + value.substring(match.index + match[0].length);
-            }
-            return value;
-        }
     }
 });
 </script>


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/dockge/blob/master/CONTRIBUTING.md

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description
When a port uses a template variable, "$PORT:8080", specified in the .env file. Currently the port link on the container view shows "$PORT" and is not clickable. This fix parses out the $TOKEN's and replaces them with the value in the .env file before creating the URL link. Also, if not present the default value specified inline, example ${PORT:-8080}, "8080" would replace the token if PORT is not specified. Handles .env file vars in double or single quotes and unescapes any in the string if needed. 

The interpreter will handle any values, not just ports, but only used for ports at this point.

It does not handle nested tokens, example ${PORT:-${DEFAULT_PORT}}

Fixes #237

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)
