### PR TITLE
Stopped "keyword" match from taking \n

### DIFF
--- a/frontend/src/pages/Compose.vue
+++ b/frontend/src/pages/Compose.vue
@@ -622,7 +622,7 @@ export default {
                         greedy: true
                     },
                     "keyword": {
-                        pattern: /^[^ :=]*(?=[:=])/m,
+                        pattern: /^\w*(?=[:=])/m,
                         greedy: true
                     },
                     "value": {


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/dockge/blob/master/CONTRIBUTING.md

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description
The keyword match for the .env highlighter took the \n and thus prism didn't do it's line management on it and threw everything off. I checked the other regex's and this doesn't occur anywhere else.

Fixes #247 #248

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)
