### PR TITLE
feat: Translate additional Thai words

### DIFF
--- a/frontend/src/lang/th.json
+++ b/frontend/src/lang/th.json
@@ -91,5 +91,13 @@
     "Allowed commands:": "คำสั่งที่อนุญาต:",
     "Internal Networks": "เครือข่ายภายใน",
     "External Networks": "เครือข่ายภายนอก",
-    "No External Networks": "ไม่มีเครือข่ายภายนอก"
+    "No External Networks": "ไม่มีเครือข่ายภายนอก",
+    "reverseProxyMsg1": "ใช้ Reverse Proxy หรือไม่?",
+    "reverseProxyMsg2": "ตรวจสอบวิธีกำหนดค่าสำหรับ WebSocket",
+    "Cannot connect to the socket server.": "ไม่สามารถเชื่อมต่อกับเซิร์ฟเวอร์ socket ได้",
+    "reconnecting...": "กำลังเชื่อมต่อใหม่…",
+    "connecting...": "กำลังเชื่อมต่อกับเซิร์ฟเวอร์ socket…",
+    "url": "URL | URLs",
+    "extra": "พิเศษ",
+    "newUpdate": "อัปเดตใหม่"
 }


### PR DESCRIPTION
- Translated into additional Thai language from the original
- Technical terms in the English language are not translated. Things that are translated into Thai may appear strange and be confused.