### PR TITLE
Allow to set password using an environment variable at runtime

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -21,3 +21,6 @@ services:
     environment:
       # Tell Dockge where is your stacks directory
       - DOCKGE_STACKS_DIR=/opt/stacks
+    # Usefull for interactive action within the container
+    stdin_open: true # docker run -i
+    tty: true        # docker run -t

--- a/extra/reset-password.ts
+++ b/extra/reset-password.ts
@@ -38,10 +38,22 @@ export const main = async () => {
 
             console.log("Found user: " + user.username);
 
-            while (true) {
-                let password = await question("New Password: ");
-                let confirmPassword = await question("Confirm New Password: ");
+            let password = "";
+            let confirmPassword = " ";
 
+            while (true) {
+                if (process.env.PASSWORD) {
+                   console.log("Found password : " + process.env.PASSWORD) ;
+                   password = process.env.PASSWORD ;
+                   confirmPassword = process.env.PASSWORD ;
+                } else {
+                   console.log("No found password: " ) ;
+                   password = await question("New Password: ");
+                   confirmPassword = await question("Confirm New Password: ");
+                }
+
+                // console.log("Password to be set :" + password);
+            
                 if (password === confirmPassword) {
                     await User.resetPassword(user.id, password);
 


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/dockge/blob/master/CONTRIBUTING.md

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description
Allow to set password using an environment variable

Fixes #(issue)
https://github.com/louislam/dockge/discussions/194 (for example)

## Type of change
Extension of reset-password.ts : 
```
docker exec -e PASSWORD=value -it dockge npm run reset-password
````

Please delete any options that are not relevant.

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ x] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
