### PR TITLE
docker compose pull skip local images

### DIFF
--- a/backend/stack.ts
+++ b/backend/stack.ts
@@ -445,7 +445,7 @@ export class Stack {
 
     async update(socket: DockgeSocket) {
         const terminalName = getComposeTerminalName(socket.endpoint, this.name);
-        let exitCode = await Terminal.exec(this.server, socket, terminalName, "docker", [ "compose", "pull" ], this.path);
+        let exitCode = await Terminal.exec(this.server, socket, terminalName, "docker", [ "compose", "pull", "--policy", "missing" ], this.path);
         if (exitCode !== 0) {
             throw new Error("Failed to pull, please check the terminal output for more information.");
         }


### PR DESCRIPTION
Updating compose pull command with a switch that skips local images. Otherwise error message is:
Error response from daemon: pull access denied for <repo>, repository does not exist or may require 'docker login': denied: requested access to the resource is denied

With this update message is similar to:
[+] Pulling 1/0
 ✔ nginx Skipped - Image is already present locally

This update requires docker-compose-plugin to be update, but that should be covered by building new base docker image.


⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/dockge/blob/master/CONTRIBUTING.md

Tick the checkbox if you understand [x]: 
- [ ] I have read and understand the pull request rules.

# Description

Fixes #(issue)

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I ran ESLint and other linters for modified files
- [ ] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
