### PR TITLE
Feature: Group stacks by its agent

### DIFF
--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -8,6 +8,7 @@ export {}
 declare module 'vue' {
   export interface GlobalComponents {
     About: typeof import('./src/components/settings/About.vue')['default']
+    AgentStackList: typeof import('./src/components/AgentStackList.vue')['default']
     Appearance: typeof import('./src/components/settings/Appearance.vue')['default']
     ArrayInput: typeof import('./src/components/ArrayInput.vue')['default']
     ArraySelect: typeof import('./src/components/ArraySelect.vue')['default']

--- a/frontend/src/components/AgentStackList.vue
+++ b/frontend/src/components/AgentStackList.vue
@@ -1,0 +1,47 @@
+<template>
+    <div class="wrapper">
+        <div class="group-header">
+            {{ agentName ?? this.$t("currentEndpoint") }}
+        </div>
+
+        <slot />
+    </div>
+
+    <hr>
+</template>
+
+<script setup lang="ts">
+interface AgentStackListProps {
+    agentName?: string;
+}
+
+defineProps<AgentStackListProps>();
+</script>
+
+<style lang="scss" scoped>
+@import "../styles/vars.scss";
+
+
+.group-header {
+    border-bottom: 1px solid #dee2e6;
+    border-radius: 10px;
+    margin-bottom: 10px;
+    font-size: 1.25rem;
+    font-weight: 500;
+    padding: 10px;
+
+    .dark & {
+        background-color: darken($color: $dark-header-bg, $amount: 1.90);
+        border-bottom: 0;
+    }
+}
+
+@media (max-width: 770px) {
+    .group-header {
+        margin: -20px;
+        margin-bottom: 10px;
+        padding: 5px;
+    }
+}
+
+</style>

--- a/frontend/src/components/AgentStackList.vue
+++ b/frontend/src/components/AgentStackList.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="wrapper">
         <div class="group-header">
-            {{ agentName ?? this.$t("currentEndpoint") }}
+            {{ agentName }}
         </div>
 
         <slot />
@@ -12,7 +12,7 @@
 
 <script setup lang="ts">
 interface AgentStackListProps {
-    agentName?: string;
+    agentName: string;
 }
 
 defineProps<AgentStackListProps>();
@@ -20,7 +20,6 @@ defineProps<AgentStackListProps>();
 
 <style lang="scss" scoped>
 @import "../styles/vars.scss";
-
 
 .group-header {
     border-bottom: 1px solid #dee2e6;

--- a/frontend/src/components/StackList.vue
+++ b/frontend/src/components/StackList.vue
@@ -189,6 +189,10 @@ export default {
 
             return result;
         },
+        /**
+         * Groups all stacks by it's agent
+         * @returns {Map<string, object} A map containing all agents with their stacks
+         */
         stackListByAgent() {
             const stacksByAgent = new Map();
             const stacks = this.$root.completeStackList;
@@ -207,10 +211,7 @@ export default {
                 stacksByAgent.get(agent).push(stack);
             }
           
-            // console.log(stacksByAgent);
-            // console.log(stacks);
             return stacksByAgent;
-            
         },
         isDarkTheme() {
             return document.body.classList.contains("dark");

--- a/frontend/src/components/StackList.vue
+++ b/frontend/src/components/StackList.vue
@@ -43,8 +43,8 @@
             </div>
         </div>
 
-        <div v-if="searchText === '' && this.$root.agentCount > 1" :style="stackListStyle" ref="stackList" class="stack-list">
-            <AgentStackList :agentName="agentName" v-for="[agentName, stacks] in stackListByAgent">
+        <div v-if="searchText === '' && $root.agentCount > 1" ref="stackList" :style="stackListStyle" class="stack-list">
+            <AgentStackList v-for="[agentName, stacks] in stackListByAgent" :agentName="agentName" :key="agentName">
                 <StackListItem
                     v-for="(stack, index) in stacks"
                     :key="index"
@@ -52,8 +52,8 @@
                     :isSelectMode="selectMode"
                     :isSelected="isSelected"
                     :select="select"
-                    :deselect="deselect"/>
-                    
+                    :deselect="deselect"
+                />
             </AgentStackList>
         </div>
 
@@ -61,7 +61,7 @@
             <div v-if="Object.keys(sortedStackList).length === 0" class="text-center mt-3">
                 <router-link to="/compose">{{ $t("addFirstStackMsg") }}</router-link>
             </div>
-            
+
             <StackListItem
                 v-for="(item, index) in sortedStackList"
                 :key="index"
@@ -83,7 +83,6 @@
 import Confirm from "../components/Confirm.vue";
 import StackListItem from "../components/StackListItem.vue";
 import { CREATED_FILE, CREATED_STACK, EXITED, RUNNING, UNKNOWN } from "../../../common/util-common";
-import AgentStackList from "./AgentStackList.vue";
 
 export default {
     components: {
@@ -212,21 +211,21 @@ export default {
         stackListByAgent() {
             const stacksByAgent = new Map();
             const stacks = this.$root.completeStackList;
-            
-           for (const key of Object.keys(stacks)) {
+
+            for (const key of Object.keys(stacks)) {
                 // Handle stacks with no suffix (from the current endpoint)
-                let [stackName, agent] = key.split("_");
+                let [ stackName, agent ] = key.split("_");
                 const stackHasEndpoint = agent !== "";
-                agent = stackHasEndpoint ? agent: this.$t("currentEndpoint");   
-                
+                agent = stackHasEndpoint ? agent : this.$t("currentEndpoint");
+
                 if (!stacksByAgent.has(agent)) {
                     stacksByAgent.set(agent, []);
                 }
 
-                const stack = stacks[!stackHasEndpoint ? `${stackName}_` : `${stackName}_${agent}`]
+                const stack = stacks[!stackHasEndpoint ? `${stackName}_` : `${stackName}_${agent}`];
                 stacksByAgent.get(agent).push(stack);
             }
-          
+
             return stacksByAgent;
         },
         isDarkTheme() {

--- a/frontend/src/components/StackList.vue
+++ b/frontend/src/components/StackList.vue
@@ -189,7 +189,29 @@ export default {
 
             return result;
         },
+        stackListByAgent() {
+            const stacksByAgent = new Map();
+            const stacks = this.$root.completeStackList;
+            
+           for (const key of Object.keys(stacks)) {
+                // Handle stacks with no suffix (from the current endpoint)
+                let [stackName, agent] = key.split("_");
+                const stackHasEndpoint = agent !== "";
+                agent = stackHasEndpoint ? agent: this.$t("currentEndpoint");   
+                
+                if (!stacksByAgent.has(agent)) {
+                    stacksByAgent.set(agent, []);
+                }
 
+                const stack = stacks[!stackHasEndpoint ? `${stackName}_` : `${stackName}_${agent}`]
+                stacksByAgent.get(agent).push(stack);
+            }
+          
+            // console.log(stacksByAgent);
+            // console.log(stacks);
+            return stacksByAgent;
+            
+        },
         isDarkTheme() {
             return document.body.classList.contains("dark");
         },

--- a/frontend/src/components/StackList.vue
+++ b/frontend/src/components/StackList.vue
@@ -42,11 +42,26 @@
                 </span>
             </div>
         </div>
-        <div ref="stackList" class="stack-list" :class="{ scrollbar: scrollbar }" :style="stackListStyle">
+
+        <div v-if="searchText === '' && this.$root.agentCount > 1" :style="stackListStyle" ref="stackList" class="stack-list">
+            <AgentStackList :agentName="agentName" v-for="[agentName, stacks] in stackListByAgent">
+                <StackListItem
+                    v-for="(stack, index) in stacks"
+                    :key="index"
+                    :stack="stack"
+                    :isSelectMode="selectMode"
+                    :isSelected="isSelected"
+                    :select="select"
+                    :deselect="deselect"/>
+                    
+            </AgentStackList>
+        </div>
+
+        <div v-else ref="stackList" class="stack-list" :class="{ scrollbar: scrollbar }" :style="stackListStyle">
             <div v-if="Object.keys(sortedStackList).length === 0" class="text-center mt-3">
                 <router-link to="/compose">{{ $t("addFirstStackMsg") }}</router-link>
             </div>
-
+            
             <StackListItem
                 v-for="(item, index) in sortedStackList"
                 :key="index"
@@ -68,6 +83,7 @@
 import Confirm from "../components/Confirm.vue";
 import StackListItem from "../components/StackListItem.vue";
 import { CREATED_FILE, CREATED_STACK, EXITED, RUNNING, UNKNOWN } from "../../../common/util-common";
+import AgentStackList from "./AgentStackList.vue";
 
 export default {
     components: {


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/dockge/blob/master/CONTRIBUTING.md

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description
I think that it would be nice when you have quite a few stacks defined across multiple agents (including the current), to have them grouped by it's agent.

In case that there aren't more agents configured, the UI will reamin exactly the same 
## Type of change

Please delete any options that are not relevant.

- User interface (UI)
- New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

![image](https://github.com/user-attachments/assets/c450723c-fee3-4ea0-8859-339415538328)

