### PR TITLE
Build frontend during docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,9 +9,9 @@ tmp
 
 # Docker extra
 docker
-frontend
 .editorconfig
 .eslintrc.cjs
 .git
 .gitignore
-README.md
+.github
+*.md

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,9 @@
 services:
   dockge:
     image: louislam/dockge:1
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
     restart: unless-stopped
     ports:
       # Host Port : Container Port

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,9 +4,19 @@
 FROM louislam/dockge:build-healthcheck AS build_healthcheck
 
 ############################################
-# Build
+# Build frontend
 ############################################
-FROM louislam/dockge:base AS build
+FROM louislam/dockge:base AS build_frontend
+WORKDIR /app
+COPY --chown=node:node . .
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install && \
+    pnpm run build:frontend
+
+############################################
+# Install node modules
+############################################
+FROM louislam/dockge:base AS build_nodemodules
 WORKDIR /app
 COPY --chown=node:node  ./package.json ./package.json
 COPY --chown=node:node  ./pnpm-lock.yaml ./pnpm-lock.yaml
@@ -18,8 +28,9 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --prod --frozen-l
 FROM louislam/dockge:base AS release
 WORKDIR /app
 COPY --chown=node:node --from=build_healthcheck /app/extra/healthcheck /app/extra/healthcheck
-COPY --from=build /app/node_modules /app/node_modules
-COPY --chown=node:node  . .
+COPY --from=build_frontend /app/frontend-dist /app/frontend-dist
+COPY --from=build_nodemodules /app/node_modules /app/node_modules
+COPY --chown=node:node . .
 RUN mkdir ./data
 
 VOLUME /app/data


### PR DESCRIPTION
- [x] I have read and understand the pull request rules.

# Description

I guess this could be viewed as a bug fix. Today it's not possible to build the Dockge container locally and have a working installation as `/app/frontend-dist` will be missing from the resulting image.
I'm suspect that when Dockge currently is built for distribution to Docker Hub, the frontend is built separately, outside the docker environment, but this requires a nodejs development environment and also is less controlled than building inside the docker environment (like the health check for example).

This PR adds an extra build stage in the main Dockerfile to build the frontend and then copies this into the final image. It also adds the build directive into `compose.yaml` so that `docker compose build` works.

This does not change any of the existing default behaviour. On a fresh system, `docker compose up` will pull from Docker Hub as before, this just supports the option to build the container locally.

Steps for a full local build, from a system with just docker installed and the repo cloned:
```
docker build -t louislam/dockge:build-healthcheck -f docker/BuildHealthCheck.Dockerfile .
docker build -t louislam/dockge:base -f docker/Base.Dockerfile .
docker compose build
```

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Other

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Output from `docker compose up` on a fresh system with these changes: [containers-from-dockerhub.txt](https://github.com/user-attachments/files/17350078/containers-from-dockerhub.txt).

Output from the build steps as noted above on a fresh system with these changes: [local-docker-build.txt](https://github.com/user-attachments/files/17350079/local-docker-build.txt).
