### PR TITLE
fix bug 176: preserve YAML comments when reordering items by matching…

### DIFF
--- a/common/util-common.ts
+++ b/common/util-common.ts
@@ -236,42 +236,62 @@ export function copyYAMLComments(doc : Document, src : Document) {
 
 /**
  * Copy yaml comments from srcItems to items
- * Typescript is super annoying here, so I have to use any here
- * TODO: Since comments are belong to the array index, the comments will be lost if the order of the items is changed or removed or added.
+ * Attempts to preserve comments by matching content rather than just array indices
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function copyYAMLCommentsItems(items : any, srcItems : any) {
+function copyYAMLCommentsItems(items: any, srcItems: any) {
     if (!items || !srcItems) {
         return;
     }
 
+    // First pass - try to match items by their content
     for (let i = 0; i < items.length; i++) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const item : any = items[i];
+        const item: any = items[i];
+        
+        // Try to find matching source item by content
+        const srcIndex = srcItems.findIndex((srcItem: any) => 
+            JSON.stringify(srcItem.value) === JSON.stringify(item.value) &&
+            JSON.stringify(srcItem.key) === JSON.stringify(item.key)
+        );
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const srcItem : any = srcItems[i];
+        if (srcIndex !== -1) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const srcItem: any = srcItems[srcIndex];
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const nextSrcItem: any = srcItems[srcIndex + 1];
 
-        if (!srcItem) {
-            continue;
-        }
+            if (item.key && srcItem.key) {
+                item.key.comment = srcItem.key.comment;
+                item.key.commentBefore = srcItem.key.commentBefore;
+            }
 
-        if (item.key && srcItem.key) {
-            item.key.comment = srcItem.key.comment;
-            item.key.commentBefore = srcItem.key.commentBefore;
-        }
+            if (srcItem.comment) {
+                item.comment = srcItem.comment;
+            }
 
-        if (srcItem.comment) {
-            item.comment = srcItem.comment;
-        }
+            // Handle comments between array items
+            if (nextSrcItem && nextSrcItem.commentBefore) {
+                if (items[i + 1]) {
+                    items[i + 1].commentBefore = nextSrcItem.commentBefore;
+                }
+            }
 
-        if (item.value && srcItem.value) {
-            if (typeof item.value === "object" && typeof srcItem.value === "object") {
-                item.value.comment = srcItem.value.comment;
-                item.value.commentBefore = srcItem.value.commentBefore;
+            // Handle trailing comments after array items
+            if (srcItem.value && srcItem.value.comment) {
+                if (item.value) {
+                    item.value.comment = srcItem.value.comment;
+                }
+            }
 
-                if (item.value.items && srcItem.value.items) {
-                    copyYAMLCommentsItems(item.value.items, srcItem.value.items);
+            if (item.value && srcItem.value) {
+                if (typeof item.value === "object" && typeof srcItem.value === "object") {
+                    item.value.comment = srcItem.value.comment;
+                    item.value.commentBefore = srcItem.value.commentBefore;
+
+                    if (item.value.items && srcItem.value.items) {
+                        copyYAMLCommentsItems(item.value.items, srcItem.value.items);
+                    }
                 }
             }
         }

--- a/common/util-common.ts
+++ b/common/util-common.ts
@@ -248,7 +248,7 @@ function copyYAMLCommentsItems(items: any, srcItems: any) {
     for (let i = 0; i < items.length; i++) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const item: any = items[i];
-        
+
         // Try to find matching source item by content
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const srcIndex = srcItems.findIndex((srcItem: any) =>

--- a/common/util-common.ts
+++ b/common/util-common.ts
@@ -250,7 +250,8 @@ function copyYAMLCommentsItems(items: any, srcItems: any) {
         const item: any = items[i];
         
         // Try to find matching source item by content
-        const srcIndex = srcItems.findIndex((srcItem: any) => 
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const srcIndex = srcItems.findIndex((srcItem: any) =>
             JSON.stringify(srcItem.value) === JSON.stringify(item.value) &&
             JSON.stringify(srcItem.key) === JSON.stringify(item.key)
         );


### PR DESCRIPTION
… content instead of position

⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/dockge/blob/master/CONTRIBUTING.md

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

Fixes #176 

### Current Behavior
Comments between array items (particularly in labels) are lost when entering edit mode because they're tied to array positions rather than content.

### Fix Implementation
- Modified `copyYAMLCommentsItems` in `common/util-common.ts`
- Changed from position-based to content-based comment preservation
- Maintains all existing functionality while fixing comment handling
- No breaking changes or additional configuration required


## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Take the following example, before the fix all comments on the label would be removed

![image](https://github.com/user-attachments/assets/e5580c5c-a599-41f9-a43f-877a1a550c6c)


After the fix, all comments remain attached to their items

![image](https://github.com/user-attachments/assets/4feb097c-9c8c-4b36-9a20-872cd4a5f280)

My first ever PR so apologies if i've missed anything!

