### PR TITLE
Support for nested stacks directory

### DIFF
--- a/backend/stack.ts
+++ b/backend/stack.ts
@@ -104,7 +104,7 @@ export class Stack {
     }
 
     get isManagedByDockge() : boolean {
-        return fs.existsSync(this.path) && fs.statSync(this.path).isDirectory();
+        return !!this._configFilePath && this._configFilePath.startsWith(this.server.stacksDir);
     }
 
     get status() : number {
@@ -153,7 +153,7 @@ export class Stack {
     }
 
     get path() : string {
-        return path.join(this.server.stacksDir, this.name);
+        return this._configFilePath || "";
     }
 
     get fullPath() : string {
@@ -261,41 +261,12 @@ export class Stack {
     }
 
     static async getStackList(server : DockgeServer, useCacheForManaged = false) : Promise<Map<string, Stack>> {
-        let stacksDir = server.stacksDir;
-        let stackList : Map<string, Stack>;
+        let stackList : Map<string, Stack> = new Map<string, Stack>();
 
         // Use cached stack list?
         if (useCacheForManaged && this.managedStackList.size > 0) {
             stackList = this.managedStackList;
-        } else {
-            stackList = new Map<string, Stack>();
-
-            // Scan the stacks directory, and get the stack list
-            let filenameList = await fsAsync.readdir(stacksDir);
-
-            for (let filename of filenameList) {
-                try {
-                    // Check if it is a directory
-                    let stat = await fsAsync.stat(path.join(stacksDir, filename));
-                    if (!stat.isDirectory()) {
-                        continue;
-                    }
-                    // If no compose file exists, skip it
-                    if (!await Stack.composeFileExists(stacksDir, filename)) {
-                        continue;
-                    }
-                    let stack = await this.getStack(server, filename);
-                    stack._status = CREATED_FILE;
-                    stackList.set(filename, stack);
-                } catch (e) {
-                    if (e instanceof Error) {
-                        log.warn("getStackList", `Failed to get stack ${filename}, error: ${e.message}`);
-                    }
-                }
-            }
-
-            // Cache by copying
-            this.managedStackList = new Map(stackList);
+            return stackList;
         }
 
         // Get status from docker compose ls
@@ -304,28 +275,33 @@ export class Stack {
         });
 
         if (!res.stdout) {
+            log.warn("getStackList", "No response from docker compose daemon when attempting to retrieve list of stacks");
             return stackList;
         }
 
         let composeList = JSON.parse(res.stdout.toString());
 
         for (let composeStack of composeList) {
-            let stack = stackList.get(composeStack.Name);
+            try {
+                let stack = new Stack(server, composeStack.Name);
+                stack._status = this.statusConvert(composeStack.Status);
 
-            // This stack probably is not managed by Dockge, but we still want to show it
-            if (!stack) {
-                // Skip the dockge stack if it is not managed by Dockge
-                if (composeStack.Name === "dockge") {
+                let composeFiles = composeStack.ConfigFiles.split(","); // it is possible for a project to have more than one config file
+                stack._configFilePath = path.dirname(composeFiles[0]);
+                stack._composeFileName = path.basename(composeFiles[0]);
+                if (stack.name === "dockge" && !stack.isManagedByDockge) {
+                    // skip dockge if not managed by dockge
                     continue;
                 }
-                stack = new Stack(server, composeStack.Name);
                 stackList.set(composeStack.Name, stack);
+            } catch (e) {
+                if (e instanceof Error) {
+                    log.warn("getStackList", `Failed to get stack ${composeStack.Name}, error: ${e.message}`);
+                }
             }
-
-            stack._status = this.statusConvert(composeStack.Status);
-            stack._configFilePath = composeStack.ConfigFiles;
         }
 
+        this.managedStackList = stackList;
         return stackList;
     }
 
@@ -373,35 +349,24 @@ export class Stack {
     }
 
     static async getStack(server: DockgeServer, stackName: string, skipFSOperations = false) : Promise<Stack> {
-        let dir = path.join(server.stacksDir, stackName);
-
+        let stack: Stack | undefined;
         if (!skipFSOperations) {
-            if (!await fileExists(dir) || !(await fsAsync.stat(dir)).isDirectory()) {
-                // Maybe it is a stack managed by docker compose directly
-                let stackList = await this.getStackList(server, true);
-                let stack = stackList.get(stackName);
-
-                if (stack) {
-                    return stack;
-                } else {
-                    // Really not found
-                    throw new ValidationError("Stack not found");
-                }
+            let stackList = await this.getStackList(server, true);
+            stack = stackList.get(stackName);
+            if (!stack || !await fileExists(stack.path) || !(await fsAsync.stat(stack.path)).isDirectory() ) {
+                throw new ValidationError(`getStack; Stack ${stackName} not found`);
             }
         } else {
-            //log.debug("getStack", "Skip FS operations");
+            // search for known stack with this name
+            if (this.managedStackList) {
+                stack = this.managedStackList.get(stackName);
+            }
+            if (!this.managedStackList || !stack) {
+                stack = new Stack(server, stackName, undefined, undefined, true);
+                stack._status = UNKNOWN;
+                stack._configFilePath = path.resolve(server.stacksDir, stackName);
+            }
         }
-
-        let stack : Stack;
-
-        if (!skipFSOperations) {
-            stack = new Stack(server, stackName);
-        } else {
-            stack = new Stack(server, stackName, undefined, undefined, true);
-        }
-
-        stack._status = UNKNOWN;
-        stack._configFilePath = path.resolve(dir);
         return stack;
     }
 
@@ -543,7 +508,6 @@ export class Stack {
                 } catch (e) {
                 }
             }
-
             return statusList;
         } catch (e) {
             log.error("getServiceStatusList", e);

--- a/backend/stack.ts
+++ b/backend/stack.ts
@@ -6,6 +6,8 @@ import { DockgeSocket, fileExists, ValidationError } from "./util-server";
 import path from "path";
 import {
     acceptedComposeFileNames,
+    acceptedComposeFileNamePattern,
+    ArbitrarilyNestedLooseObject,
     COMBINED_TERMINAL_COLS,
     COMBINED_TERMINAL_ROWS,
     CREATED_FILE,
@@ -280,6 +282,7 @@ export class Stack {
         }
 
         let composeList = JSON.parse(res.stdout.toString());
+        let pathSearchTree: ArbitrarilyNestedLooseObject = {}; // search structure for matching paths
 
         for (let composeStack of composeList) {
             try {
@@ -294,10 +297,68 @@ export class Stack {
                     continue;
                 }
                 stackList.set(composeStack.Name, stack);
+
+                // add project path to search tree so we can quickly decide if we have seen it before later
+                // e.g. path "/opt/stacks" would yield the tree { opt: stacks: {} }
+                path.join(stack._configFilePath, stack._composeFileName).split(path.sep).reduce((searchTree, pathComponent) => {
+                    if (pathComponent == "") {
+                        return searchTree;
+                    }
+                    if (!searchTree[pathComponent]) {
+                        searchTree[pathComponent] = {};
+                    }
+                    return searchTree[pathComponent];
+                }, pathSearchTree);
             } catch (e) {
                 if (e instanceof Error) {
-                    log.warn("getStackList", `Failed to get stack ${composeStack.Name}, error: ${e.message}`);
+                    log.error("getStackList", `Failed to get stack ${composeStack.Name}, error: ${e.message}`);
                 }
+            }
+        }
+
+        // Search stacks directory for compose files not associated with a running compose project (ie. never started through CLI)
+        try {
+            // Hopefully the user has access to everything in this directory! If they don't, log the error. It is a small price to pay for fast searching.
+            let rawFilesList = fs.readdirSync(server.stacksDir, {
+                recursive: true,
+                withFileTypes: true
+            });
+            let acceptedComposeFiles = rawFilesList.filter((dirEnt: fs.Dirent) => dirEnt.isFile() && !!dirEnt.name.match(acceptedComposeFileNamePattern));
+            log.debug("getStackList", `Folder scan yielded ${acceptedComposeFiles.length} files`);
+            for (let composeFile of acceptedComposeFiles) {
+                // check if we have seen this file before
+                let fullPath = composeFile.parentPath;
+                let previouslySeen = fullPath.split(path.sep).reduce((searchTree: ArbitrarilyNestedLooseObject | boolean, pathComponent) => {
+                    if (pathComponent == "") {
+                        return searchTree;
+                    }
+
+                    // end condition
+                    if (searchTree == false || !(searchTree as ArbitrarilyNestedLooseObject)[pathComponent]) {
+                        return false;
+                    }
+
+                    // path (so far) has been previously seen
+                    return (searchTree as ArbitrarilyNestedLooseObject)[pathComponent];
+                }, pathSearchTree);
+                if (!previouslySeen) {
+                    // a file with an accepted compose filename has been found that did not appear in `docker compose ls`. Use its config file path as a temp name
+                    log.info("getStackList", `Found project unknown to docker compose: ${fullPath}/${composeFile.name}`);
+                    let [ configFilePath, configFilename, inferredProjectName ] = [ fullPath, composeFile.name, path.basename(fullPath) ];
+                    if (stackList.get(inferredProjectName)) {
+                        log.info("getStackList", `... but it was ignored. A project named ${inferredProjectName} already exists`);
+                    } else {
+                        let stack = new Stack(server, inferredProjectName);
+                        stack._status = UNKNOWN;
+                        stack._configFilePath = configFilePath;
+                        stack._composeFileName = configFilename;
+                        stackList.set(inferredProjectName, stack);
+                    }
+                }
+            }
+        } catch (e) {
+            if (e instanceof Error) {
+                log.error("getStackList", `Got error searching for undiscovered stacks:\n${e.message}`);
             }
         }
 

--- a/backend/stack.ts
+++ b/backend/stack.ts
@@ -355,7 +355,7 @@ export class Stack {
                         log.info("getStackList", `... but it was ignored. A project named ${inferredProjectName} already exists`);
                     } else {
                         let stack = new Stack(server, inferredProjectName);
-                        stack._status = UNKNOWN;
+                        stack._status = CREATED_FILE;
                         stack._configFilePath = configFilePath;
                         stack._composeFileName = configFilename;
                         stackList.set(inferredProjectName, stack);

--- a/backend/stack.ts
+++ b/backend/stack.ts
@@ -188,6 +188,12 @@ export class Stack {
                 throw new ValidationError("Stack name already exists");
             }
 
+            // If this is a new stack that has no compose file yet, use the stack name as directory
+            if (dir === "") {
+                this._configFilePath = path.join(this.server.stacksDir, this.name);
+                dir = this.path;
+            }
+
             // Create the stack folder
             await fsAsync.mkdir(dir);
         } else {
@@ -412,7 +418,7 @@ export class Stack {
     static async getStack(server: DockgeServer, stackName: string, skipFSOperations = false) : Promise<Stack> {
         let stack: Stack | undefined;
         if (!skipFSOperations) {
-            let stackList = await this.getStackList(server, true);
+            let stackList = await this.getStackList(server);
             stack = stackList.get(stackName);
             if (!stack || !await fileExists(stack.path) || !(await fsAsync.stat(stack.path)).isDirectory() ) {
                 throw new ValidationError(`getStack; Stack ${stackName} not found`);

--- a/common/util-common.ts
+++ b/common/util-common.ts
@@ -21,6 +21,10 @@ export interface LooseObject {
     [key: string]: any
 }
 
+export interface ArbitrarilyNestedLooseObject {
+    [key: string]: ArbitrarilyNestedLooseObject | Record<string, never>;
+}
+
 export interface BaseRes {
     ok: boolean;
     msg?: string;
@@ -113,6 +117,13 @@ export const acceptedComposeFileNames = [
     "docker-compose.yml",
     "compose.yml",
 ];
+
+// Make a regex out of accepted compose file names
+export const acceptedComposeFileNamePattern = new RegExp(
+    acceptedComposeFileNames
+        .map((filename: string) => filename.replace(".", "\\$&"))
+        .join("|")
+);
 
 /**
  * Generate a decimal integer number from a string


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/dockge/blob/master/CONTRIBUTING.md

Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description
This PR accompanies the discussion in https://github.com/louislam/dockge/discussions/214. 

Currently, dockge assumes all stacks are exactly one level deep in the stacks directory, and the "name" of a project equals the name of the folder containing it. This assumption is not quite right, and leads to weird behavior where dockge can be "tricked" into thinking a random folder is a docker compose project, or will simply not distinguish between two separate projects. 

Some examples of where this assumption breaks: 
- you have multiple projects living in the same folder, perhaps with more than one config file (e.g. `$stacksDir/project/compose-dev.yml` and `$stacksDir/project/compose-prod.yml`). If there is also a `compose.yml` dockge will assign both projects the name "project" and not distinguish between them. 
- you have multiple instances of one project (e.g. `$stacksDir/application1/authentik` and `$stacksDir/application2/authentik`). Dockge will assign both projects the name `authentik` and will not distinguish them. 
- All of these also apply in case of a naming conflict with a project that is run from outside the configured stacks directory (e.g. `$notStacksDir/application3/authentik` will produce yet another naming conflict). 
- If the config file name (like `compose-dev.yml` is not in the `acceptedComposeFileNames`) dockge will simply not work with this project. This behavior is undocumented.

In these cases the user will tell `docker compose` to tag the project with different names. So `docker compose` will be aware of the difference but dockge will behave strangely. Plus, people with many (say, 20+) projects running on one machine will most certainly want to use some nesting to organize their stacks directory. For these reasons, I think letting `docker compose` should be the main source of truth. 

A real example I had while testing this is I had a `server` directory I want to use as my `stacksDir` that contains a folder called `authentik`. This folder is actually a volume mount for my authentik project, and does not contain a config file. The actual authentik stack is running from a different location on my machine. Even though `dockge` tries to skip folders that don't contain an `acceptedComposeFilename`, the name of the folder matches the name of a project that appears in the output of `docker compose ls`, so dockge thinks it is a project managed by dockge and then says it cannot find the configuration file:

![Screenshot From 2024-12-14 19-14-32](https://github.com/user-attachments/assets/9f4fddb3-2913-40cc-a115-43e4d51dc459)

This PR treats `docker compose ls` as the main source of truth, and puts the folder scan afterwards as a "nice to have" for discovering unknown projects. And it fixes the issue described above!

![Screenshot From 2024-12-14 22-04-04](https://github.com/user-attachments/assets/b1652320-8bf1-4186-852b-647849a95eb9)

There are two commits in this PR that cover the two pieces of functionality changed. They can be reviewed separately, and the first half can be merged independently if you don't like the second. This changes some existing functionality, but everything that used to work should work the same as before, if not slightly better.

[The first part](https://github.com/louislam/dockge/pull/687/commits/fc4ad7ff292ce202dffb84d1c89eefbaabce7a36) focuses on the `stacks.ts` logic that assumes a stack "managed by dockge" means it lives in the folder `$stacksDir + $projectName`. It asks docker compose for a list of projects and treats all the projects where the config file starts with `stacksDir` as being managed by dockge (current `master` does a folder search then asks `docker compose` for services not managed by dockge, but they all go into the string map which can cause conflicts). 

[The second part](https://github.com/louislam/dockge/pull/687/commits/2c29aea921531377e378de2de2f8a312f1c38c9e) restores dockge's ability to "discover" projects that had never been run through the CLI, by adding the folder search _after_ the call to docker compose. But it makes that search recursive using [node FS](https://github.com/nodejs/node/blob/2d4e35c74d3bbfc4ea342662dbaae8a7dfd06fa6/lib/fs.js#L1385). In case of a naming conflict between a "known" project and a "discovered" project, it keeps the "known" project but adds some extra logging and makes dockge's behavior extra transparent. Naming conflicts between projects "known" to docker compose will still happen if the user makes an error using docker compose (e.g.. not tagging projects with names), but at least dockge's behavior will match `docker compose`'s. 

Fixes #(issue)
https://github.com/louislam/dockge/discussions/214

## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)

Please do not use any external image service. Instead, just paste in or drag and drop the image here, and it will be uploaded automatically.
