### PR TITLE
feat: add cloudflare turnstile captcha on login

### DIFF
--- a/frontend/src/components/Login.vue
+++ b/frontend/src/components/Login.vue
@@ -30,6 +30,8 @@
                         </label>
                     </div>
                 </div>
+                <div v-if="siteKey" id="turnstile-widget" ref="turnstile" class="mt-3 mb-3"></div>
+
                 <button class="w-100 btn btn-primary" type="submit" :disabled="processing">
                     {{ $t("Login") }}
                 </button>
@@ -52,10 +54,14 @@ export default {
             token: "",
             res: null,
             tokenRequired: false,
+            captchaToken: "",
+            siteKey: "",
         };
     },
 
     mounted() {
+
+        this.getTurnstileSiteKey();
         document.title += " - Login";
     },
 
@@ -71,15 +77,82 @@ export default {
         submit() {
             this.processing = true;
 
-            this.$root.login(this.username, this.password, this.token, (res) => {
+            if (this.siteKey && !this.captchaToken) {
+                console.error("CAPTCHA token is missing or invalid.");
                 this.processing = false;
+                this.res = { ok: false,
+                    msg: "Invalid CAPTCHA!" };
+                this.resetTurnstile(); // Reset the widget
+                return;
+            }
 
+            this.$root.login(this.username, this.password, this.token, this.captchaToken, (res) => {
+                this.processing = false;
                 if (res.tokenRequired) {
                     this.tokenRequired = true;
+                } else if (!res.ok) {
+                    this.res = res;
+                    this.resetTurnstile();
                 } else {
                     this.res = res;
                 }
             });
+        },
+
+        resetTurnstile() {
+            if (window.turnstile && this.$refs.turnstile) {
+                console.log("Resetting Turnstile widget...");
+                window.turnstile.reset(this.$refs.turnstile);
+                this.captchaToken = ""; // Clear the old token
+            }
+        },
+
+        getTurnstileSiteKey() {
+            this.$root.getTurnstileSiteKey((res) => {
+                if (res.ok) {
+                    this.siteKey = res.siteKey;
+                    if (this.siteKey) {
+                        console.log("Turnstile site key is provided. Loading Turnstile script...");
+                        const script = document.createElement("script");
+                        script.src = "https://challenges.cloudflare.com/turnstile/v0/api.js";
+                        script.async = true;
+                        script.defer = true;
+                        script.onload = () => {
+                            console.log("Turnstile script loaded successfully.");
+                            this.initializeTurnstile();
+                        };
+                        script.onerror = () => {
+                            console.error("Failed to load Turnstile script.");
+                        };
+                        document.head.appendChild(script);
+                        console.log("Turnstile script loaded...");
+                    } else {
+                        console.warn("Turnstile site key is not provided. Widget will not be rendered.");
+                    }
+
+                } else {
+                    console.error("Failed to fetch Turnstile site key from socket:", res.msg);
+                }
+            });
+        },
+
+        /**
+         * Initialize the Turnstile widget
+         */
+        initializeTurnstile() {
+            if (window.turnstile) {
+                console.log("Initializing Turnstile widget...");
+                window.turnstile.render(this.$refs.turnstile, {
+                    sitekey: this.siteKey,
+                    callback: (token) => {
+                        this.captchaToken = token; // Save the token
+                    },
+                    "error-callback": () => {
+                        console.error("Turnstile error occurred");
+                        this.captchaToken = null;
+                    },
+                });
+            }
         },
 
     },

--- a/frontend/src/mixins/socket.ts
+++ b/frontend/src/mixins/socket.ts
@@ -319,18 +319,30 @@ export default defineComponent({
         },
 
         /**
+         * Get configured Cloudflare Turnstile Site Key from backend
+         * @param {loginCB} callback Callback to call with result
+         */
+        getTurnstileSiteKey(callback) {
+            this.getSocket().emit("getTurnstileSiteKey", (res) => {
+                callback(res);
+            });
+        },
+
+        /**
          * Send request to log user in
          * @param {string} username Username to log in with
          * @param {string} password Password to log in with
          * @param {string} token User token
+         * @param {string} captchaToken captcha token
          * @param {loginCB} callback Callback to call with result
          * @returns {void}
          */
-        login(username : string, password : string, token : string, callback) {
+        login(username : string, password : string, token : string, captchaToken : string, callback) {
             this.getSocket().emit("login", {
                 username,
                 password,
                 token,
+                captchaToken,
             }, (res) => {
                 if (res.tokenRequired) {
                     callback(res);


### PR DESCRIPTION
Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description
If a free to use, non-limiting captcha solution is added to the public facing login form, it would provide more security to the application. 

I love this project, and i use it on my homelab and private cloud daily. One issue that scratches the back of my mind was there's no captcha in the login form. Forms without these are prone to so many attacks. With this simple widgets, most of the vunerabilities are handled, without the efforts of the dev. So i wanted to try contributing. 

I like how Cloudflare's Turnstile Captcha solution, it's free to use (without limitation), interchangable with Google's Captcha(as written in its docs). So i spent some time learning Dockge code base, and added this functionality without changing any default behaviour. With this pr, if a user supply Turnstile's site key and secret key(on env), it will be automatically enabled on login form and its backend validation. 

## Type of change

- User interface (UI)
- New feature (non-breaking change which adds functionality)
- Other
- This change requires a documentation update

### Change details

- In `backend/socket-handlers/main-socket-handler.ts`
  - Added a new socket event that returns Turnstile site key from env `TURNSTILE_SITE_KEY`
  - Added captcha server side  validation method
  - updated login handler to do a backend validation if site key and secret key is defined in env
- In `frontend/src/mixins/socket.ts`
  - added method that uses the turnstile site key fetching
  - updated the login method to send captcha token with the user information
- In `frontend/src/components/Login.vue`
  - added Turnstile captcha widget that renders conditionally(with site key existing check)
  - added site key fetching operation on mounted(if site key returns from backend import the necessary js files and render the widget)
  - updated the login operation to check and send the captcha token if exists.

- (No-Changes Sent - For Testing) added TURNSTILE_SITE_KEY and TURNSTILE_SECRET_KEY to `npm run dev`, added new script that does local docker build that can be run with this `npm run build:docker-local` , and test the functionality directly and through docker image

  ```
  # on package.json:
   ...
   "scripts": {
    ...
          "dev": "TURNSTILE_SITE_KEY=0x4AAAAAAXXXXXXXX TURNSTILE_SECRET_KEY=0x4AAAAAAXXXX concurrently -k -r \"wait-on tcp:5000 && npm run dev:backend \" \"npm run dev:frontend\"",
          "build:docker-local": "npm run build:frontend && docker buildx build -t dockge:nightly --target nightly -f ./docker/Dockerfile .",
    ...
  ```
- (No-Changes Sent - For Testing) added these in the docker compose file, ran `docker compose up` and checked it.
  ```
  # on compose.yml
  ...
      environment:
      ...  
      - TURNSTILE_SITE_KEY=0x4AAAAAAXXXXXXXX 
      - TURNSTILE_SECRET_KEY=0x4AAAAAAXXXX
  ```
- Checked the functionality when an invalid credentials are entered, captcha widget resets and does not send old token.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)

## Screenshots (if any)
![resim](https://github.com/user-attachments/assets/cdf4d920-2175-4f8c-b4fa-592dc678172b)
![resim](https://github.com/user-attachments/assets/baf1dfed-6057-450a-b241-bf32160028ee)

