### PR TITLE
feat: adding default compose template setting

### DIFF
--- a/common/util-common.ts
+++ b/common/util-common.ts
@@ -428,3 +428,11 @@ function traverseYAML(pair : Pair, env : DotenvParseOutput) : void {
     }
 }
 
+export const defaultComposeTemplate = `services:
+  nginx:
+    image: nginx:latest
+    restart: unless-stopped
+    ports:
+      - 8080:80
+networks: {}
+`;

--- a/frontend/src/components/settings/General.vue
+++ b/frontend/src/components/settings/General.vue
@@ -57,6 +57,23 @@
                 <div class="form-text"></div>
             </div>
 
+            <!-- Default Compose Template -->
+            <div class="mb-4">
+                <label class="form-label" for="defaultTemplateURL">
+                    {{ $t("defaultComposeTemplate") }}
+                </label>
+
+                <code-mirror
+                    ref="editor"
+                    v-model="settings.template"
+                    :extensions="extensions"
+                    minimal
+                    wrap="true"
+                    dark="true"
+                    tab="true"
+                />
+            </div>
+
             <!-- Save Button -->
             <div>
                 <button class="btn btn-primary" type="submit">
@@ -71,10 +88,26 @@
 
 import dayjs from "dayjs";
 import { timezoneList } from "../../util-frontend";
+import CodeMirror from "vue-codemirror6";
+import { yaml } from "@codemirror/lang-yaml";
+import { dracula as editorTheme } from "thememirror";
+import { lineNumbers } from "@codemirror/view";
+import { defaultComposeTemplate } from "../../../../common/util-common.ts";
 
 export default {
     components: {
+        CodeMirror
+    },
 
+    setup() {
+        const extensions = [
+            editorTheme,
+            yaml(),
+            lineNumbers(),
+        ];
+        return {
+            extensions: extensions
+        };
     },
 
     data() {
@@ -85,7 +118,11 @@ export default {
 
     computed: {
         settings() {
-            return this.$parent.$parent.$parent.settings;
+            const settings = this.$parent.$parent.$parent.settings;
+            if (!settings.template) {
+                settings.template = defaultComposeTemplate;
+            }
+            return settings;
         },
         saveSettings() {
             return this.$parent.$parent.$parent.saveSettings;

--- a/frontend/src/lang/en.json
+++ b/frontend/src/lang/en.json
@@ -28,6 +28,7 @@
     "cancel": "Cancel",
     "stackNotManagedByDockgeMsg": "This stack is not managed by Dockge.",
     "primaryHostname": "Primary Hostname",
+    "defaultComposeTemplate": "Default Compose Template",
     "general": "General",
     "container": "Container | Containers",
     "scanFolder": "Scan Stacks Folder",

--- a/frontend/src/pages/Compose.vue
+++ b/frontend/src/pages/Compose.vue
@@ -250,6 +250,8 @@ import { dracula as editorTheme } from "thememirror";
 import { lineNumbers, EditorView } from "@codemirror/view";
 import { parseDocument, Document } from "yaml";
 
+import { defaultComposeTemplate } from "../../../common/util-common.ts";
+
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import {
     COMBINED_TERMINAL_COLS,
@@ -265,14 +267,6 @@ import NetworkInput from "../components/NetworkInput.vue";
 import dotenv from "dotenv";
 import { ref } from "vue";
 
-const template = `
-services:
-  nginx:
-    image: nginx:latest
-    restart: unless-stopped
-    ports:
-      - "8080:80"
-`;
 const envDefault = "# VARIABLE=value #comment";
 
 let yamlErrorTimeout = null;
@@ -478,8 +472,16 @@ export default {
                 composeYAML = this.$root.composeTemplate;
                 this.$root.composeTemplate = "";
             } else {
-                composeYAML = template;
+                composeYAML = defaultComposeTemplate;
             }
+
+            this.$root.getSocket().emit("getSettings", (res) => {
+                if (res.ok && res.data.template) {
+                    this.stack.composeYAML = res.data.template;
+                    this.yamlCodeChange();
+                }
+            });
+
             if (this.$root.envTemplate) {
                 composeENV = this.$root.envTemplate;
                 this.$root.envTemplate = "";


### PR DESCRIPTION
Tick the checkbox if you understand [x]: 
- [x] I have read and understand the pull request rules.

# Description

This adds a small setting to configure the default compose template used. I only saw the rules after making the changes locally, that's why I didn't opened a discussion as I already did it. Still ok if you don't want this feature :)

Without this feature, the default compose template is just a hardcoded constant in the code :(

## Why would this feature be useful

In our infra, we have some network that every docker must be connected to, to be reachable from the reverse proxy. Would be very cool to be able to permanently add this network to the default template used.

## Type of change

- User interface (UI)
- New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [ ] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings


## Screenshots (if any)
<img width="954" height="405" alt="image" src="https://github.com/user-attachments/assets/c7c5ec6c-5287-40d8-99e3-bbc00d2991c9" />
