### PR TITLE
Add configurable base path

### DIFF
--- a/backend/dockge-server.ts
+++ b/backend/dockge-server.ts
@@ -21,7 +21,7 @@ import { R } from "redbean-node";
 import { genSecret, isDev, LooseObject } from "../common/util-common";
 import { generatePasswordHash } from "./password-hash";
 import { Bean } from "redbean-node/dist/bean";
-import { Arguments, Config, DockgeSocket } from "./util-server";
+import { Arguments, Config, DockgeSocket, normalizedBasePath } from "./util-server";
 import { DockerSocketHandler } from "./agent-socket-handlers/docker-socket-handler";
 import expressStaticGzip from "express-static-gzip";
 import path from "path";
@@ -37,6 +37,7 @@ import { AgentSocketHandler } from "./agent-socket-handler";
 import { AgentSocket } from "../common/agent-socket";
 import { ManageAgentSocketHandler } from "./socket-handlers/manage-agent-socket-handler";
 import { Terminal } from "./terminal";
+import { parse as parseHtml } from "node-html-parser";
 
 export class DockgeServer {
     app : Express;
@@ -141,6 +142,10 @@ export class DockgeServer {
                 type: Boolean,
                 optional: true,
                 defaultValue: false,
+            },
+            basePath: {
+                type: String,
+                optional: true,
             }
         });
 
@@ -155,7 +160,15 @@ export class DockgeServer {
         this.config.dataDir = args.dataDir || process.env.DOCKGE_DATA_DIR || "./data/";
         this.config.stacksDir = args.stacksDir || process.env.DOCKGE_STACKS_DIR || defaultStacksDir;
         this.config.enableConsole = args.enableConsole || process.env.DOCKGE_ENABLE_CONSOLE === "true" || false;
+        this.config.basePath = args.basePath || process.env.DOCKGE_BASE_PATH || "/";
         this.stacksDir = this.config.stacksDir;
+
+        // Normalize base path for internal handling by removing any trailing `/`
+        if (this.config.basePath !== "/" && this.config.basePath.endsWith("/")) {
+            const oldBasePath = this.config.basePath;
+            this.config.basePath = this.config.basePath.slice(0, -1);
+            console.log("Remove trailing slash: ", oldBasePath, this.config.basePath);
+        }
 
         log.debug("server", this.config);
 
@@ -170,6 +183,8 @@ export class DockgeServer {
                 process.exit(1);
             }
         }
+
+        this.mutateIndexHTML();
 
         // Create express
         this.app = express();
@@ -187,13 +202,27 @@ export class DockgeServer {
             this.httpServer = http.createServer(this.app);
         }
 
+        log.info("server", "Base path: " + this.config.basePath);
+
+        // Trailing slash redirect (e.g. `/dockge` → `/dockge/`)
+        if (this.config.basePath !== "/") {
+            this.app.get(this.config.basePath, async (request, response, next) => {
+                if (request.path === this.config.basePath) {
+                    response.redirect(normalizedBasePath(this.config.basePath));
+                    response.end();
+                } else {
+                    next();
+                }
+            });
+        }
+
         // Binding Routers
         for (const router of this.routerList) {
-            this.app.use(router.create(this.app, this));
+            this.app.use(normalizedBasePath(this.config.basePath), router.create(this.app, this));
         }
 
         // Static files
-        this.app.use("/", expressStaticGzip("frontend-dist", {
+        this.app.use(normalizedBasePath(this.config.basePath), expressStaticGzip("frontend-dist", {
             enableBrotli: true,
         }));
 
@@ -212,6 +241,7 @@ export class DockgeServer {
 
         // Create Socket.io
         this.io = new socketIO.Server(this.httpServer, {
+            path: normalizedBasePath(this.config.basePath, "socket.io"),
             cors,
             allowRequest: (req, callback) => {
                 let isOriginValid = true;
@@ -722,4 +752,15 @@ export class DockgeServer {
         return `${protocol}://${host}:${this.config.port}`;
     }
 
+    /**
+     * Mutates the `base` element's `href` within {@link indexHTML} to point to {@link Config.basePath}. Adds a trailing
+     * slash to base path if Dockge us not served under root, as otherwise the browser would interpret the last segment
+     * as a file, in effect truncating the base path (e.g. `/dockge` → `/`).
+     */
+    mutateIndexHTML() {
+        const html = parseHtml(this.indexHTML);
+        const base = html.querySelector("head base");
+        base?.setAttribute("href", normalizedBasePath(this.config.basePath));
+        this.indexHTML = html.toString();
+    }
 }

--- a/backend/util-server.ts
+++ b/backend/util-server.ts
@@ -31,6 +31,7 @@ export interface Arguments {
     dataDir? : string;
     stacksDir? : string;
     enableConsole? : boolean;
+    basePath?: string;
 }
 
 // Some config values are required
@@ -103,4 +104,16 @@ export function fileExists(file : string) {
     return fs.promises.access(file, fs.constants.F_OK)
         .then(() => true)
         .catch(() => false);
+}
+
+/**
+ * Normalizes given {@link basePath} to be never `undefined` and end with with a slash, optionally with {@link extra}
+ * appended. If {@link basePath} is `undefined`, `/` is substituted.
+ *
+ * @param basePath value or undefined
+ * @param extra optional value to append
+ * @returns normalized value
+ */
+export function normalizedBasePath(basePath: string | undefined, extra: string | undefined = undefined) {
+    return ((basePath !== undefined && basePath !== "/") ? basePath + "/" : "/") + (extra ?? "");
 }

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,7 +8,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./data:/app/data
-        
+
       # If you want to use private registries, you need to share the auth file with Dockge:
       # - /root/.docker/:/root/.docker
 
@@ -20,3 +20,5 @@ services:
     environment:
       # Tell Dockge where is your stacks directory
       - DOCKGE_STACKS_DIR=/opt/stacks
+      # If set, Dockge is served under given path (e.g. `/dockge`). If omitted, Dockge is served under `/`.
+      - DOCKGE_BASE_PATH

--- a/extra/healthcheck.go
+++ b/extra/healthcheck.go
@@ -52,7 +52,12 @@ func main() {
 		protocol = "http"
 	}
 
-	url := protocol + "://" + hostname + ":" + port
+	path := os.Getenv("DOCKGE_BASE_PATH")
+	if len(path) == 0 {
+		path = "/"
+	}
+
+	url := protocol + "://" + hostname + ":" + port + path
 
 	log.Println("Checking " + url)
 	resp, err := client.Get(url)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <base href="%BASE_URL%" />
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/frontend/src/mixins/socket.ts
+++ b/frontend/src/mixins/socket.ts
@@ -167,7 +167,8 @@ export default defineComponent({
                 this.socketIO.connecting = true;
             }, 1500);
 
-            socket = io(url);
+            // Construct the socket URL by using the HTML document's `base` value of `href` as the path
+            socket = io(url, { path: new URL("socket.io", document.baseURI).pathname });
 
             // Handling events from agents
             let agentSocket = new AgentSocket();

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,33 +4,48 @@ import Components from "unplugin-vue-components/vite";
 import { BootstrapVueNextResolver } from "unplugin-vue-components/resolvers";
 import viteCompression from "vite-plugin-compression";
 import "vue";
+import "dotenv/config";
 
 const viteCompressionFilter = /\.(js|mjs|json|css|html|svg)$/i;
 
 // https://vitejs.dev/config/
-export default defineConfig({
-    server: {
-        port: 5000,
-    },
-    define: {
-        "FRONTEND_VERSION": JSON.stringify(process.env.npm_package_version),
-    },
-    root: "./frontend",
-    build: {
-        outDir: "../frontend-dist",
-    },
-    plugins: [
-        vue(),
-        Components({
-            resolvers: [ BootstrapVueNextResolver() ],
-        }),
-        viteCompression({
-            algorithm: "gzip",
-            filter: viteCompressionFilter,
-        }),
-        viteCompression({
-            algorithm: "brotliCompress",
-            filter: viteCompressionFilter,
-        }),
-    ],
+export default defineConfig(({ command }) => {
+    return {
+        /* For `build`, set `base` to a relative path to allow for runtime configuration. For `serve`, set the value of
+        `DOCKGE_BASE_PATH` or its default of `/` if none was given. */
+        base: command === "build" ? "./" : (process.env.DOCKGE_BASE_PATH?.concat("/") || "/"),
+        server: {
+            port: 5000,
+        },
+        define: {
+            "FRONTEND_VERSION": JSON.stringify(process.env.npm_package_version),
+        },
+        root: "./frontend",
+        build: {
+            outDir: "../frontend-dist",
+        },
+        plugins: [
+            vue({
+                /* Extend the list of asset tags for base path handling to include object tags, which are used to link
+                SVG icons. */
+                template: {
+                    transformAssetUrls: {
+                        img: [ "src" ],
+                        object: [ "data" ],
+                    }
+                }
+            }),
+            Components({
+                resolvers: [ BootstrapVueNextResolver() ],
+            }),
+            viteCompression({
+                algorithm: "gzip",
+                filter: viteCompressionFilter,
+            }),
+            viteCompression({
+                algorithm: "brotliCompress",
+                filter: viteCompressionFilter,
+            }),
+        ],
+    };
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
                 "knex": "~2.5.1",
                 "limiter-es6-compat": "~2.1.2",
                 "mysql2": "~3.12.0",
+                "node-html-parser": "^7.1.0",
                 "promisify-child-process": "~4.1.2",
                 "redbean-node": "~0.3.3",
                 "semver": "^7.7.1",
@@ -2906,7 +2907,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
             "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/bootstrap": {
@@ -3637,6 +3637,34 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/css-select": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+            "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "boolbase": "^1.0.0",
+                "css-what": "^6.1.0",
+                "domhandler": "^5.0.2",
+                "domutils": "^3.0.1",
+                "nth-check": "^2.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/css-what": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+            "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">= 6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
         "node_modules/cssesc": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -3924,6 +3952,61 @@
                 "node": ">=6.0.0"
             }
         },
+        "node_modules/dom-serializer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+            "license": "MIT",
+            "dependencies": {
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.2",
+                "entities": "^4.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+            }
+        },
+        "node_modules/domelementtype": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+            "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ],
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/domhandler": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "domelementtype": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 4"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/domutils": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+            "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "dom-serializer": "^2.0.0",
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domutils?sponsor=1"
+            }
+        },
         "node_modules/dotenv": {
             "version": "16.3.2",
             "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.2.tgz",
@@ -4107,7 +4190,6 @@
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
             "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.12"
@@ -5416,6 +5498,15 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/he": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+            "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+            "license": "MIT",
+            "bin": {
+                "he": "bin/he"
             }
         },
         "node_modules/http-cache-semantics": {
@@ -7026,6 +7117,16 @@
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
+        "node_modules/node-html-parser": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-7.1.0.tgz",
+            "integrity": "sha512-iJo8b2uYGT40Y8BTyy5ufL6IVbN8rbm/1QK2xffXU/1a/v3AAa0d1YAoqBNYqaS4R/HajkWIpIfdE6KcyFh1AQ==",
+            "license": "MIT",
+            "dependencies": {
+                "css-select": "^5.1.0",
+                "he": "1.2.0"
+            }
+        },
         "node_modules/nopt": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
@@ -7068,7 +7169,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
             "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "boolbase": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "knex": "~2.5.1",
         "limiter-es6-compat": "~2.1.2",
         "mysql2": "~3.12.0",
+        "node-html-parser": "^7.1.0",
         "promisify-child-process": "~4.1.2",
         "redbean-node": "~0.3.3",
         "semver": "^7.7.1",


### PR DESCRIPTION
- [X] I have read and understand the pull request rules.

# Description

## Synopsis

Adds capabilities to Dockge for deployments under a custom base path (e.g. `http://localhost:5001/dockge/`).

## Rationale

Currently Dockge lacks the ability to be deployed under a base path other than the default `/`, which is a common requirement for services running behind a reverse proxy. This PR modifies the frontend, backend and the Docker Compose manifest to allow for Dockge to run under any path.

The base path may be set during deployment – no frontend or image re-building required.

Works in local development via `npm run dev`, too.

## Changed files

Most of the magic happens by setting Vite's [base option](https://vite.dev/config/shared-options#base) and exposing it as `<base href="%BASE_URL%">`. While the build time value of `./` solves some of the requirements, the remaining code is to change the relative path to the value of `DOCKGE_BASE_PATH` at runtime.

The code around it for the server part is about mutating `index.hmtl` (in `mutateIndexHTML()`) to include a dynamic `<base href="..." />` , while on client side, the `base` tag's `href` value is used for URL construction (`socket = io(url, { path: new URL("socket.io", document.baseURI).pathname });`).

### Project
- package.json
  - add `node-html-parser` (MIT licensed, dependencies MIT and BSD-2-Clause licensed)
- package-lock.json
  - as above

### Frontend
- index.html
  - Add `base` tag
- vite.config.ts
  - Read .env (to use the same values as the server from .env)
  - Add `base` option
  - Configure Vue plugin to modify `object` assets
- socket.ts
  - Use path from `base` tag

### Backend
- dockge-server.ts
  - add `basePath` option
  - mutate `index.html` with `basePath`
- util-server.ts
  - add helper function

### Docker
- compose.yaml
  - add `DOCKGE_BASE_PATH` env var
- healthcheck.go
  - modify URL to include base path

## Testing

As Dockge seemingly does not have any automated tests suites, all tests were conducted manually.

This script may be used as a quick way for assessment:

```bash
#!/usr/bin/env bash

set -e
set -x

npm install
npm run build:frontend
docker buildx build --tag louislam/dockge:build-healthcheck --file docker/BuildHealthCheck.Dockerfile .
docker buildx build --tag louislam/dockge:base --file docker/Base.Dockerfile .
node ./extra/env2arg.js docker buildx build --tag louislam/dockge:latest --tag louislam/dockge:1 --target release --file docker/Dockerfile .
```

Run the script without configuring `DOCKGE_BASE_PATH`:

```bash
docker compose up --force-recreate
```

Dockge should be running under `http://localhost:5001/`.

Now configure a base path by setting `DOCKGE_BASE_PATH` per CLI :

```bash
DOCKGE_BASE_PATH=/dockge docker compose up --force-recreate
```

Dockge should be now be running under `http://localhost:5001/dockge/`.

If you prefer to keep settings in a `.env` file, be aware these are also picked up by `npm run dev:frontend` and `npm run dev:backend`.

## Reverse Proxy Example

When running behind a reverse proxy, both the base path with and without a trailing slash should be proxied. E.g, this snippet configures Caddy to act as a reverse proxy when running Dockge with `DOCKGE_BASE_PATH=/dockge`.

```caddy
handle /dockge {
    reverse_proxy dockge:5001
}

handle /dockge/* {
    reverse_proxy dockge:5001
}
```

Note that the above example is just for illustration and may require addition configuration, such as disabling buffers, etc.

## Notes

- Aims to resolve discussion [add BASE_PATH variable #874](https://github.com/louislam/dockge/discussions/874)
- Aims to resolve issue https://github.com/louislam/dockge/issues/903

## Type of change

Please delete any options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings
- [ ] My code needed automated testing. I have added them (this is optional task)
