### PR TITLE
Add input field for filtering terminal logs

### DIFF
--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -11,11 +11,8 @@ declare module 'vue' {
     Appearance: typeof import('./src/components/settings/Appearance.vue')['default']
     ArrayInput: typeof import('./src/components/ArrayInput.vue')['default']
     ArraySelect: typeof import('./src/components/ArraySelect.vue')['default']
-    BButton: typeof import('bootstrap-vue-next')['BButton']
     BDropdown: typeof import('bootstrap-vue-next')['BDropdown']
     BDropdownItem: typeof import('bootstrap-vue-next')['BDropdownItem']
-    BFormGroup: typeof import('bootstrap-vue-next')['BFormGroup']
-    BFormInput: typeof import('bootstrap-vue-next')['BFormInput']
     BModal: typeof import('bootstrap-vue-next')['BModal']
     Confirm: typeof import('./src/components/Confirm.vue')['default']
     Container: typeof import('./src/components/Container.vue')['default']
@@ -33,8 +30,5 @@ declare module 'vue' {
     Terminal: typeof import('./src/components/Terminal.vue')['default']
     TwoFADialog: typeof import('./src/components/TwoFADialog.vue')['default']
     Uptime: typeof import('./src/components/Uptime.vue')['default']
-  }
-  export interface ComponentCustomProperties {
-    vBModal: typeof import('bootstrap-vue-next')['vBModal']
   }
 }

--- a/frontend/src/components/Terminal.vue
+++ b/frontend/src/components/Terminal.vue
@@ -71,6 +71,8 @@ export default {
             first: true,
             terminalInputBuffer: "",
             cursorPosition: 0,
+            filterQuery: "",    // Search string from parent Compose.vue
+            fullLogBuffer: ""   // Memory buffer where the entire log history from the server is stored
         };
     },
     created() {
@@ -102,6 +104,14 @@ export default {
         // Bind to a div
         this.terminal.open(this.$refs.terminal);
         this.terminal.focus();
+
+        // First log capture
+        // Saves everything the server sent during the first page load to a buffer
+        this.terminal.onWriteParsed(() => {
+            if (this.first && !this.filterQuery) {
+                this.fullLogBuffer = this.getBuffer();
+            }
+        });
 
         // Add right-click context menu handler for paste
         this.$refs.terminal.addEventListener("contextmenu", this.handleContextMenu);
@@ -149,37 +159,82 @@ export default {
     },
 
     methods: {
+        // Method for redrawing the screen when entering text into the filter
+        applyFilter() {
+            this.terminal.reset();
+            this.terminal.clear();
+            const allLines = this.fullLogBuffer.split("\n");
+            // If the filter is cleared, we return all logs from memory in their original form
+            if (!this.filterQuery) {
+                allLines.forEach(line => this.terminal.writeln(line));
+                return;
+            }
+            const query = this.filterQuery.toLowerCase();
+            allLines.forEach(line => {
+                // Clear the string of Docker-colored special characters before searching
+                const cleanLine = line.replace(/\x1B\[[0-9;]*[a-zA-Z]/g, "");
+                if (cleanLine.toLowerCase().includes(query)) {
+                    // Safe regular expression with escaped special characters
+                    const regex = new RegExp(`(${this.escapeRegExp(this.filterQuery)})`, 'gi');
+                    // Wrap the match in ANSI code for a yellow background (\x1B[43m) and write it to the screen
+                    this.terminal.writeln(line.replace(regex, "\x1B[43m\x1B[30m$1\x1B[0m"));
+                }
+            });
+        },
+        // Extract raw text from the active xterm.js screen
+        getBuffer() {
+            let bufferText = "";
+            const buffer = this.terminal.buffer.active;
+            for (let i = 0; i < buffer.length; i++) {
+                const line = buffer.getLine(i);
+                if (line) bufferText += line.translateToString(true) + "\n";
+            }
+            return bufferText;
+        },
+        // Escaping special characters (+, ?, ., ()) so that RegExp doesn't fail with an error
+        escapeRegExp(string) {
+            return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        },
+        // Modified socket binding method
         bind(endpoint, name) {
-            // Workaround: normally this.name should be set, but it is not sometimes, so we use the parameter, but eventually this.name and name must be the same name
-            if (name) {
-                this.$root.unbindTerminal(name);
-                this.$root.bindTerminal(endpoint, name, this.terminal);
-                console.debug("Terminal bound via parameter: " + name);
-            } else if (this.name) {
-                this.$root.unbindTerminal(this.name);
-                this.$root.bindTerminal(this.endpoint, this.name, this.terminal);
-                console.debug("Terminal bound: " + this.name);
-            } else {
-                console.debug("Terminal name not set");
+            const targetName = name || this.name;
+            if (targetName) {
+                this.$root.unbindTerminal(targetName);
+                this.$root.bindTerminal(endpoint || this.endpoint, targetName, this.terminal);
+                // Safely intercept the original socket write method
+                const originalWrite = this.terminal.write.bind(this.terminal);
+                this.terminal.write = (data) => {
+                    if (typeof data === "string") {
+                        // Always write new logs to the background history buffer
+                        this.fullLogBuffer += data;
+                        if (!this.filterQuery) {
+                            // If there is no filter, stream the original output to the screen
+                            originalWrite(data);
+                        } else {
+                            // If the filter is active, filter and highlight new logs in real time
+                            const cleanData = data.replace(/\x1B\[[0-9;]*[a-zA-Z]/g, "");
+                            if (cleanData.toLowerCase().includes(this.filterQuery.toLowerCase())) {
+                                const regex = new RegExp(`(${this.escapeRegExp(this.filterQuery)})`, 'gi');
+                                originalWrite(data.replace(regex, "\x1B[43m\x1B[30m$1\x1B[0m"));
+                            }
+                        }
+                    } else {
+                        originalWrite(data);
+                    }
+                };
             }
         },
 
         removeInput() {
             const textAfterCursorLength = this.terminalInputBuffer.length - this.cursorPosition;
             const spaces = " ".repeat(textAfterCursorLength);
-            const backspaceCount = this.terminalInputBuffer.length;
-            const backspaces = "\b \b".repeat(backspaceCount);
+            this.terminal.write(spaces + "\b \b".repeat(this.terminalInputBuffer.length));
             this.cursorPosition = 0;
-            this.terminal.write(spaces + backspaces);
             this.terminalInputBuffer = "";
         },
 
         clearCurrentLine() {
-            // Move cursor to the beginning of the input and clear it
-            const backspaces = "\b".repeat(this.cursorPosition);
-            const spaces = " ".repeat(this.terminalInputBuffer.length);
-            const moreBackspaces = "\b".repeat(this.terminalInputBuffer.length);
-            this.terminal.write(backspaces + spaces + moreBackspaces);
+            this.terminal.write("\b".repeat(this.cursorPosition) + " ".repeat(this.terminalInputBuffer.length) + "\b".repeat(this.terminalInputBuffer.length));
         },
 
         mainTerminalConfig() {

--- a/frontend/src/pages/Compose.vue
+++ b/frontend/src/pages/Compose.vue
@@ -151,10 +151,26 @@
                             </div>
                         </div>
                     </div>
-
                     <!-- Combined Terminal Output -->
                     <div v-show="!isEditMode">
-                        <h4 class="mb-3">{{ $t("terminal") }}</h4>
+                        <!-- Added input for filter -->
+                       <div class="terminal-header-inline"
+                            style="display: flex; justify-content: space-between; align-items: center; width: 100%; margin-bottom: 12px; padding: 5px 0;">
+                            <h4 class="mb-0">{{ $t("terminal") }}</h4>
+                            <div class="dockge-search-wrapper"
+                                style="position: relative; display: flex; align-items: center; width: 100%; max-width: 450px;">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+                                    stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    style="position: absolute; left: 14px; width: 16px; height: 16px; color: #6e7681; pointer-events: none;">
+                                    <circle cx="11" cy="11" r="8"></circle>
+                                    <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+                                </svg>
+                                <input :value="filterText" @input="onFilterInput($event)"
+                                    placeholder="Log filter (e.g. error or success)" class="filter-input-pill-inline"
+                                    style="background-color: #0d1117; color: #c9d1d9; border: 1px solid #30363d; padding: 8px 14px 8px 42px; border-radius: 20px; font-size: 14px; width: 100%; outline: none;" />
+                            </div>
+                        </div>
                         <Terminal
                             ref="combinedTerminal"
                             class="mb-3 terminal"
@@ -162,7 +178,7 @@
                             :endpoint="endpoint"
                             :rows="combinedTerminalRows"
                             :cols="combinedTerminalCols"
-                            style="height: 315px;"
+                            style="height: 915px;"
                         ></Terminal>
                     </div>
                 </div>
@@ -344,6 +360,7 @@ export default {
             newContainerName: "",
             stopServiceStatusTimeout: false,
             stopDockerStatsTimeout: false,
+            filterText: "",
         };
     },
     computed: {
@@ -842,6 +859,16 @@ export default {
                 }
             });
         },
+
+        // The input handler passes the filter text to the terminal and starts redrawing the logs
+        onFilterInput(event) {
+            const val = event.target.value;
+            this.filterText = val;
+            if (this.$refs.combinedTerminal) {
+                this.$refs.combinedTerminal.filterQuery = val;
+                this.$refs.combinedTerminal.applyFilter();
+            }
+        },
     }
 };
 </script>
@@ -861,5 +888,12 @@ export default {
 .agent-name {
     font-size: 13px;
     color: $dark-font-color3;
+}
+</style>
+
+<style scoped>
+.filter-input-pill-inline:focus {
+    border-color: #58a6ff !important;
+    box-shadow: 0 0 0 3px rgba(88, 166, 255, 0.15) !important;
 }
 </style>


### PR DESCRIPTION
⚠️⚠️⚠️ Since we do not accept all types of pull requests and do not want to waste your time. Please be sure that you have read pull request rules:
https://github.com/louislam/dockge/blob/master/CONTRIBUTING.md

- [x] I have read and understand the pull request rules.

# Description

An input field for filtering logs using a buffer for accumulating new events has been added, and the terminal window size for displaying logs has been increased. Search keywords are highlighted in yellow (see screenshot), while the current colors in the log are preserved.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I ran ESLint and other linters for modified files
- [x] I have performed a self-review of my own code and tested it
- [x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [x] My changes generate no new warnings

## Screenshots

<img width="1406" height="2044" alt="image" src="https://github.com/user-attachments/assets/03ea46eb-5f76-4938-afc6-0fdfba63ebe1" />

<img width="1413" height="1504" alt="image" src="https://github.com/user-attachments/assets/50e58f7a-286b-497b-976d-ba5d4ddba0a7" />