### PR TITLE
Fix: #964  .env is no longer updated

### DIFF
--- a/backend/stack.ts
+++ b/backend/stack.ts
@@ -193,14 +193,26 @@ export class Stack {
                 throw new ValidationError("Stack not found");
             }
         }
-
         // Write or overwrite the compose.yaml
         fs.writeFileSync(path.join(dir, this._composeFileName), this.composeYAML);
+        // Change the ownership of the stack files to the uid and gid of the container
         if (process.env.PUID && process.env.PGID) {
             const uid = Number(process.env.PUID);
             const gid = Number(process.env.PGID);
             fs.lchownSync(dir, uid, gid);
             fs.chownSync(path.join(dir, this._composeFileName), uid, gid);
+        }
+
+        // Write or overwrite the .env
+        const envPath = path.join(dir, ".env");
+        if (await fileExists(envPath) || this.composeENV.trim() !== "") {
+            await fsAsync.writeFile(envPath, this.composeENV);
+            // Change the ownership of the .env file to the uid and gid of the container
+            if (process.env.PUID && process.env.PGID) {
+                const uid = Number(process.env.PUID);
+                const gid = Number(process.env.PGID);
+                fs.chownSync(envPath, uid, gid);
+            }
         }
     }
 


### PR DESCRIPTION
Fixed Bug #964  introduced in  https://github.com/louislam/dockge/commit/46ce4228a5a91a629152b06aa2f1ca28cbe22ab2

Tick the checkbox if you understand [x]: 
- [ x] I have read and understand the pull request rules.

# Description

Fixes #964  .env is no longer updated
## Type of change

Please delete any options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
## Checklist

- [ x] My code follows the style guidelines of this project
- [ x] I ran ESLint and other linters for modified files
- [ x] I have performed a self-review of my own code and tested it
- [ x] I have commented my code, particularly in hard-to-understand areas
  (including JSDoc for methods)
- [ x] My changes generate no new warnings
